### PR TITLE
Don't use NormalizedString for storing paths

### DIFF
--- a/config.py
+++ b/config.py
@@ -31,12 +31,12 @@ conf.registerGroup(TriviaTime, 'hints')
 # CONFIGURATION
 # file locations for database and question
 conf.registerChannelValue(TriviaTime.admin, 'db', 
-        registry.NormalizedString("""plugins/TriviaTime/storage/db/trivia.db""", 
+        registry.String("""plugins/TriviaTime/storage/db/trivia.db""", 
                 """Location of sqlite database file""")
         )
 
 conf.registerChannelValue(TriviaTime.admin, 'file', 
-        registry.NormalizedString("""plugins/TriviaTime/storage/questions""", 
+        registry.String("""plugins/TriviaTime/storage/questions""", 
                 """Location of question file. Reload the plugin if changed.""")
         )
 


### PR DESCRIPTION
Long NormalizedString values get serialized with line breaks and spaces,
which break paths when restarting.
Plus, it trims consecutive spaces, which also breaks paths.